### PR TITLE
Use PyCryptodome instead of PyCrypto

### DIFF
--- a/.travis.install-dependencies.sh
+++ b/.travis.install-dependencies.sh
@@ -2,7 +2,7 @@
 
 # Best practice for Travis CI is to use Python virtualenv instead of the system Python.
 # Unfortunately, the virtualenv which Travis CI sets up has a broken bsddb module,
-# doesn't have PyCrypto preinstalled, and doesn't play nice with dependencies from
+# doesn't have PyCryptodome preinstalled, and doesn't play nice with dependencies from
 # the Armory .deb distribution, so we just use the system Python instead.
 
 set -e

--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -2442,7 +2442,7 @@ class WalletNull(object):
 
 
 # Creates two decryption functions (in global namespace), aes256_cbc_decrypt() and aes256_ofb_decrypt(),
-# using either PyCrypto if it's available or a pure python library. The created functions each take
+# using either PyCryptodome if it's available or a pure python library. The created functions each take
 # three bytestring arguments: key, iv, ciphertext. ciphertext must be a multiple of 16 bytes, and any
 # padding present is not stripped.
 missing_pycrypto_warned = False
@@ -2459,12 +2459,12 @@ def load_aes256_library(force_purepython = False, warnings = True):
             return Crypto  # just so the caller can check which version was loaded
         except ImportError:
             if warnings and not missing_pycrypto_warned:
-                print(prog+": warning: can't find PyCrypto, using aespython instead", file=sys.stderr)
+                print(prog+": warning: can't find PyCryptodome, using aespython instead", file=sys.stderr)
                 missing_pycrypto_warned = True
 
     # This version is attributed to GitHub user serprex; please see the aespython
     # README.txt for more information. It measures over 30x faster than the more
-    # common "slowaes" package (although it's still 30x slower than the PyCrypto)
+    # common "slowaes" package (although it's still 30x slower than the PyCryptodome)
     #
     import aespython
     expandKey = aespython.key_expander.expandKey

--- a/btcrecover/test/test_passwords.py
+++ b/btcrecover/test/test_passwords.py
@@ -1067,15 +1067,15 @@ class Test07WalletDecryption(unittest.TestCase):
     def test_armory(self):
         self.wallet_tester("armory-wallet.wallet")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_bitcoincore(self):
         self.wallet_tester("bitcoincore-wallet.dat")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_electrum(self):
         self.wallet_tester("electrum-wallet")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_electrum27(self):
         self.wallet_tester("electrum27-wallet")
 
@@ -1098,7 +1098,7 @@ class Test07WalletDecryption(unittest.TestCase):
         self.wallet_tester("electrum1-upgradedto-electrum27-wallet")
 
     @skipUnless(can_load_coincurve, "requires coincurve")
-    @skipUnless(can_load_pycrypto,  "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,  "requires PyCryptodome")
     def test_electrum28(self):
         self.wallet_tester("electrum28-wallet")
 
@@ -1106,27 +1106,27 @@ class Test07WalletDecryption(unittest.TestCase):
     def test_electrum28_pp(self):
         self.wallet_tester("electrum28-wallet", force_purepython=True)
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_multibit(self):
         self.wallet_tester("multibit-wallet.key")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
     def test_multibithd(self):
         self.wallet_tester("mbhd.wallet.aes")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
     def test_multibithd_v0_5_0(self):
         self.wallet_tester(os.path.join("multibithd-v0.5.0", "mbhd.wallet.aes"))
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     @skipUnless(can_load_protobuf, "requires protobuf")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
     def test_bitcoinj(self):
         self.wallet_tester("bitcoinj-wallet.wallet")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     @skipUnless(can_load_protobuf, "requires protobuf")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
     def test_androidpin(self):
@@ -1138,38 +1138,38 @@ class Test07WalletDecryption(unittest.TestCase):
     def test_androidpin_unencrypted(self):
         self.wallet_tester("bitcoinj-wallet.wallet", android_backuppass="IGNORED")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
     def test_bither(self):
         self.wallet_tester("bither-wallet.db")
 
-    @skipUnless(can_load_pycrypto,  "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,  "requires PyCryptodome")
     @skipUnless(can_load_scrypt,    "requires a binary implementation of pylibscrypt")
     @skipUnless(can_load_coincurve, "requires coincurve")
     @skipUnless(has_ripemd160,      "requires that hashlib implements RIPEMD-160")
     def test_bither_hdonly(self):
         self.wallet_tester("bither-hdonly-wallet.db")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_msigna(self):
         self.wallet_tester("msigna-wallet.vault")
 
-    @skipUnless(can_load_pycrypto,  "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,  "requires PyCryptodome")
     @skipUnless(has_hashlib_pbkdf2, "requires Python 2.7.8+")
     def test_blockchain_v0(self):
         self.wallet_tester("blockchain-v0.0-wallet.aes.json")
 
-    @skipUnless(can_load_pycrypto,  "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,  "requires PyCryptodome")
     @skipUnless(has_hashlib_pbkdf2, "requires Python 2.7.8+")
     def test_blockchain_v2(self):
         self.wallet_tester("blockchain-v2.0-wallet.aes.json")
 
-    @skipUnless(can_load_pycrypto,  "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,  "requires PyCryptodome")
     @skipUnless(has_hashlib_pbkdf2, "requires Python 2.7.8+")
     def test_blockchain_secondpass_v0(self):
         self.wallet_tester("blockchain-v0.0-wallet.aes.json", blockchain_mainpass="btcr-test-password")
 
-    @skipUnless(can_load_pycrypto,  "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,  "requires PyCryptodome")
     @skipUnless(has_hashlib_pbkdf2, "requires Python 2.7.8+")
     def test_blockchain_secondpass_v2(self):
         self.wallet_tester("blockchain-v2.0-wallet.aes.json", blockchain_mainpass="btcr-test-password")
@@ -1361,97 +1361,97 @@ class Test08KeyDecryption(unittest.TestCase):
     def test_armory(self):
         self.key_tester("YXI6r7mks1qvph4G+rRT7WlIptdr9qDqyFTfXNJ3ciuWJ12BgWX5Il+y28hLNr/u4Wl49hUi4JBeq6Jz9dVBX3vAJ6476FEAACAABAAAAGGwnwXRpPbBzC5lCOBVVWDu7mUJetBOBvzVAv0IbrboDXqA8A==")
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_bitcoincore(self):
         self.key_tester("YmM65iRhIMReOQ2qaldHbn++T1fYP3nXX5tMHbaA/lqEbLhFk6/1Y5F5x0QJAQBI/maR")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_bitcoincore_unicode(self):
         self.key_tester("YmM6XAL2X19VfzlKJfc+7LIeNrB2KC8E9DWe1YhhOchPoClvwftbuqjXKkfdAAARmggo", unicode_pw=True)
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_multibit(self):
         self.key_tester("bWI6oikebfNQTLk75CfI5X3svX6AC7NFeGsgTNXZfA==")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_multibit_unicode(self):
         self.key_tester("bWI6YK6OX8bVP2Ar/j2dZBBQ+F0pEn8kZK6rlXiAWA==", unicode_pw=True)
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_multidoge(self):
         self.key_tester("bWI6IdK25nMhHI9n4zlb1cUtWBl7mL7gh7ZtxkYaDw==")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_multidoge_unicode(self):
         self.key_tester("bWI6ry78W+RkeTi2dVt2omZMfXRi46xDsIhr0jKN3g==", unicode_pw=True)
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_androidwallet(self):
         self.key_tester("bWI6Ii/ZEeDjUJKq704wzUxKudpvAralnrOQtXM4og==")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_androidwallet_unicode(self):
         self.key_tester("bWI6f1QdX7xXtC0zG7XK9pTGTifie5FUeAGhJ05esw==", unicode_pw=True)
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_androidknc(self):
         self.key_tester("bWI6n6ccPSkbrmxQpdfKNAOBFppQLGloPDHE2sOucQ====")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_androidknc_unicode(self):
         self.key_tester("bWI6TaEiZOBE+52jqe09jKcVa39KqvOpJxbpEtCVPQ==", unicode_pw=True)
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
     def test_multibithd(self):
         self.key_tester("bTU6LbH/+ROEa0cQ0inH7V3thcYVi5WL/4uGfU9/JQgsPZ6Y3zps")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     @skipUnless(can_load_scrypt,         "requires a binary implementation of pylibscrypt")
     def test_multibithd_unicode(self):
         self.key_tester("bTU6M7wXqwXQWo4o22eN50PNnsYVi5WL/4uGfU9/JQgsPZ42BGtS", unicode_pw=True)
     #
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
     def test_multibithd_v0_5_0(self):
         self.key_tester("bTU6Uh0pDwAKoBrKkMbf2ARxmyftdKB5dsqDUWTsD1fVrnsM2EYW")
 
     @skipUnless(can_load_protobuf, "requires protobuf")
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_bitcoinj(self):
         self.key_tester("Ymo6MacXiCd1+6/qtPc5rCaj6qIGJbu5tX2PXQXqF4Df/kFrjNGMDMHqrwBAAAAIAAEAZwdBow==")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
     @skipUnless(can_load_protobuf,       "requires protobuf")
     @skipUnless(can_load_scrypt,         "requires a binary implementation of pylibscrypt")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_bitcoinj_unicode(self):
         self.key_tester("Ymo6hgWTejxVYfL/LLF4af8j2RfEsi5y16kTQhECWnn9iCt8AmGWPoPomQBAAAAIAAEAfNRA3A==", unicode_pw=True)
 
     @skipUnless(can_load_scrypt,   "requires a binary implementation of pylibscrypt")
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_bither(self):
         self.key_tester("YnQ6PocfHvWGVbCzlVb9cUtPDjosnuB7RoyspTEzZZAqURlCsLudQaQ4IkIW8YE=")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
     @skipUnless(can_load_scrypt,         "requires a binary implementation of pylibscrypt")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_bither_unicode(self):
         self.key_tester("YnQ6ENNU1KSJlzC8FMfAq/MHgWgaZkxpiByt/vLQ/UdP2NlCsLudQaQ4IjTbPcw=", unicode_pw=True)
 
-    @skipUnless(can_load_pycrypto, "requires PyCrypto")
+    @skipUnless(can_load_pycrypto, "requires PyCryptodome")
     def test_msigna(self):
         self.key_tester("bXM6SWd6U+qTKOzQDfz8auBL1/tzu0kap7NMOqctt7U0nA8XOI6j6BCjxCsc7mU=")
     #
     @skipUnless(lambda: tstr == unicode, "Unicode mode only")
-    @skipUnless(can_load_pycrypto,       "requires PyCrypto")
+    @skipUnless(can_load_pycrypto,       "requires PyCryptodome")
     def test_msigna_unicode(self):
         self.key_tester("bXM6i9OkMzrIJqWvpM+Dxq795jeFFxiB6DtBwuGmeEtfHLLOjMvoJRAWeSsf+Pg=", unicode_pw=True)
 

--- a/docs/Extract_Scripts.md
+++ b/docs/Extract_Scripts.md
@@ -190,7 +190,7 @@ When you (or someone else) runs *btcrecover* to search for passwords, you will n
     ...
     Password found: xxxx
 
-Please note that you must either download the entire *btcrecover* package which includes an AES decryption library, or you must already have PyCrypto installed in order to use the *extract-blockchain-second-hash.py* script.
+Please note that you must either download the entire *btcrecover* package which includes an AES decryption library, or you must already have PyCryptodome installed in order to use the *extract-blockchain-second-hash.py* script.
 
 #### Blockchain.info Technical Details ####
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -13,26 +13,26 @@ Locate your wallet type in the list below, and follow the instructions in the se
  * Armory 0.93+ on Windows - [Python 2.7](#python-27) **64-bit** (x86-64)
  * Armory 0.92+ on Linux - no additional requirements
  * Armory 0.92+ on OS X - some versions of Armory may not work correctly on OS X, if in doubt use version 0.95.1
- * Bitcoin Unlimited/Classic/XT/Core - [Python 2.7](#python-27),  optional: [PyCrypto](#pycrypto)
- * MultiBit Classic - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * MultiBit HD - [Python 2.7](#python-27), [scrypt](#scrypt), optional: [PyCrypto](#pycrypto)
- * Electrum (1.x or 2.x) - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * Electrum 2.8+ fully encrypted wallets - [Python 2.7](#python-27) (2.7.8+ recommended), [coincurve](Seedrecover_Quick_Start_Guide.md#installation), optional: [PyCrypto](#pycrypto)
+ * Bitcoin Unlimited/Classic/XT/Core - [Python 2.7](#python-27),  optional: [PyCryptodome](#pycryptodome)
+ * MultiBit Classic - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * MultiBit HD - [Python 2.7](#python-27), [scrypt](#scrypt), optional: [PyCryptodome](#pycryptodome)
+ * Electrum (1.x or 2.x) - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * Electrum 2.8+ fully encrypted wallets - [Python 2.7](#python-27) (2.7.8+ recommended), [coincurve](Seedrecover_Quick_Start_Guide.md#installation), optional: [PyCryptodome](#pycryptodome)
  * BIP-39 Bitcoin passphrases (e.g. TREZOR) - [Python 2.7](#python-27) (2.7.8+ recommended), [coincurve](Seedrecover_Quick_Start_Guide.md#installation)
  * BIP-39 Ethereum passphrases (e.g. TREZOR) - [Python 2.7](#python-27) (2.7.8+ recommended), [coincurve and pysha3](Seedrecover_Quick_Start_Guide.md#installation)
- * Hive for OS X - [Python 2.7](#python-27), [scrypt](#scrypt), [Google protobuf](#google-protocol-buffers), optional: [PyCrypto](#pycrypto)
- * mSIGNA (CoinVault) - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * Blockchain.info - [Python 2.7](#python-27) (2.7.8+ recommended), recommended: [PyCrypto](#pycrypto)
- * Bitcoin Wallet for Android/BlackBerry backup - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * Bitcoin Wallet for Android/BlackBerry spending PIN - [Python 2.7](#python-27), [scrypt](#scrypt), [Google protobuf](#google-protocol-buffers), optional: [PyCrypto](#pycrypto)
- * KnC Wallet for Android backup - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * Bither - [Python 2.7](#python-27), [scrypt](#scrypt), [coincurve](Seedrecover_Quick_Start_Guide.md#installation), optional: [PyCrypto](#pycrypto)
- * Litecoin-Qt - [Python 2.7](#python-27),  optional: [PyCrypto](#pycrypto)
- * Electrum-LTC - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * Litecoin Wallet for Android - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * Dogecoin Core - [Python 2.7](#python-27),  optional: [PyCrypto](#pycrypto)
- * MultiDoge - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
- * Dogecoin Wallet for Android - [Python 2.7](#python-27), recommended: [PyCrypto](#pycrypto)
+ * Hive for OS X - [Python 2.7](#python-27), [scrypt](#scrypt), [Google protobuf](#google-protocol-buffers), optional: [PyCryptodome](#pycryptodome)
+ * mSIGNA (CoinVault) - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * Blockchain.info - [Python 2.7](#python-27) (2.7.8+ recommended), recommended: [PyCryptodome](#pycryptodome)
+ * Bitcoin Wallet for Android/BlackBerry backup - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * Bitcoin Wallet for Android/BlackBerry spending PIN - [Python 2.7](#python-27), [scrypt](#scrypt), [Google protobuf](#google-protocol-buffers), optional: [PyCryptodome](#pycryptodome)
+ * KnC Wallet for Android backup - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * Bither - [Python 2.7](#python-27), [scrypt](#scrypt), [coincurve](Seedrecover_Quick_Start_Guide.md#installation), optional: [PyCryptodome](#pycryptodome)
+ * Litecoin-Qt - [Python 2.7](#python-27),  optional: [PyCryptodome](#pycryptodome)
+ * Electrum-LTC - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * Litecoin Wallet for Android - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * Dogecoin Core - [Python 2.7](#python-27),  optional: [PyCryptodome](#pycryptodome)
+ * MultiDoge - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
+ * Dogecoin Wallet for Android - [Python 2.7](#python-27), recommended: [PyCryptodome](#pycryptodome)
 
 
 ### Windows ###
@@ -71,24 +71,40 @@ If (and only if) you decide *not* to install the latest version of Python 2, you
         curl https://bootstrap.pypa.io/get-pip.py | sudo python
 
 
-### PyCrypto ###
+### PyCryptodome ###
 
-PyCrypto is not strictly required for any wallet, however it offers a 20x speed improvement for wallets that tag it as recommended in the list above.
+PyCryptodome is not strictly required for any wallet, however it offers a 20x speed improvement for wallets that tag it as recommended in the list above.
 
 ##### Windows #####
 
-Download and run the PyCrypto 2.6 installer for Python 2.7, either the 32-bit version or the 64-bit version to match your version of Python. This is either `PyCrypto 2.6 for Python 2.7 32bit` or `PyCrypto 2.6 for Python 2.7 64bit` available here: <http://www.voidspace.org.uk/python/modules.shtml#pycrypto>
+To install PyCryptodome on Windows, you can simply do it with:
+
+    pip install pycryptodome
+
+If you don't have pip installed, you can read the instructions here: <https://pip.pypa.io/en/stable/installing/>
+
+**Note:** PyCryptodome is a forked and enhanced version of the now inactive PyCrypto package. So it is best to not have both installed at the same time. If you had installed PyCrypto earlier, you can uninstall it with:
+
+    pip uninstall pycrypto
+
+You can do this before installing PyCryptodome, so these do not interfere.
 
 ##### Linux #####
 
-Many distributions include PyCrypto pre-installed, check your distribution’s package management system to see if it is available (it is often called “python-crypto”). If not, try installing it from PyPI, for example on Debian-like distributions (including Ubuntu), if this doesn't work:
+Many distributions include PyCryptodome pre-installed, check your distribution’s package management system to see if it is available (it is often called “python-crypto”). If not, try installing it from PyPI, for example on Debian-like distributions (including Ubuntu), if this doesn't work:
 
     sudo apt-get install python-crypto
 
 then try this instead:
 
     sudo apt-get install python-pip
-    sudo pip install pycrypto
+    sudo pip install pycryptodome
+
+**Note:** PyCryptodome is a forked and enhanced version of the now inactive PyCrypto package. So it is best to not have both installed at the same time. If you had installed PyCrypto earlier, you can uninstall it with:
+
+    sudo pip uninstall pycrypto
+
+You can do this before installing PyCryptodome, so these do not interfere.
 
 ##### OS X #####
 
@@ -96,10 +112,22 @@ then try this instead:
 
         xcode-select --install
 
- 2. Type this to install PyCrypto:
+ 2. Type this to install PyCryptodome:
 
-        sudo pip install pycrypto
+        sudo pip install pycryptodome
 
+**Note:** PyCryptodome is a forked and enhanced version of the now inactive PyCrypto package. So it is best to not have both installed at the same time. If you had installed PyCrypto earlier, you can uninstall it with:
+
+    sudo pip uninstall pycrypto
+
+You can do this before installing PyCryptodome, so these do not interfere.
+
+##### Further information #####
+
+If you have any issues in configuring PyCryptodome, you check out it's:
+- Documentation: https://www.pycryptodome.org/en/latest/src/introduction.html
+- GitHub repo: https://github.com/Legrandin/pycryptodome
+- Package page: https://pypi.python.org/pypi/pycryptodome
 
 ### scrypt ###
 
@@ -121,7 +149,7 @@ then try this instead:
  4. Copy the chosen `libsodium.dll` file into your `C:\Python27` directory.
 
  5. Download and install one of the two update packages below from Microsoft, either the 32-bit version or the 64-bit version (the second) to match the version of Python that you've installed.
- 
+
     * [Microsoft Visual C++ Redistributable for Visual Studio 2017 **32-bit**](https://go.microsoft.com/fwlink/?LinkId=746572)
     * [Microsoft Visual C++ Redistributable for Visual Studio 2017 **64-bit**](https://go.microsoft.com/fwlink/?LinkId=746571)
 
@@ -202,4 +230,4 @@ Install the Google's Python protobuf library, for example on Debian-like distrib
 
     Note that you may need to change either the directory (on the first line) or the filename (on the second) depending on the filename you downloaded and its location.
 
-[PyCrypto](#pycrypto) is also recommended for Bitcoin Unlimited/Classic/XT/Core or Litecoin-Qt wallets for a 2x speed improvement.
+[PyCryptodome](#pycryptodome) is also recommended for Bitcoin Unlimited/Classic/XT/Core or Litecoin-Qt wallets for a 2x speed improvement.

--- a/extract-scripts/extract-blockchain-second-hash.py
+++ b/extract-scripts/extract-blockchain-second-hash.py
@@ -32,7 +32,7 @@ import sys, os.path, base64, json, getpass, re, itertools, uuid, zlib, struct
 ################################### Cryptography Libraries ###################################
 
 # Creates two decryption functions (in global namespace), aes256_cbc_decrypt() and aes256_ofb_decrypt(),
-# and one key derivation function, pbkdf2(), using either PyCrypto if it's available or pure python
+# and one key derivation function, pbkdf2(), using either PyCryptodome if it's available or pure python
 # libraries. The created decryption functions each take three bytestring arguments: key, iv, ciphertext.
 # ciphertext must be a multiple of 16 bytes, and any padding present is not stripped. pbkdf2() takes
 # four arguments: password, salt, iter_count, len (len is the desired key length)


### PR DESCRIPTION
This pull request is motivated by #165 which lets users install `PyCryptodome` instead of the now inactive `PyCrypto` package. Since `PyCryptodome` installs all modules under the same `Crypto` package that `PyCrypto` used, all I had to do was change the references and documentation throughout the project. No actual code, including variables and functions had to be changed.

However, what I have used here is a "drop-in replacement" of `PyCrypto`, which allows us to not make any changes to the code and continue to use the same `Crypto` package as mentioned earlier. `PyCryptodome` offers another library independent of the old `PyCrypto` and can be installed as `PyCryptodomex`, where all modules are installed under the `Cryptodome` package. 

With this pull request, old users of `btcrecover` who don't install `PyCryptodome` will not be affected (at least, immediately), but if we go the other route of using `PyCryptodomex` and changing the code to use `Cryptodome` instead of `Crypto`, then they will be forced to install it in order to use `btcrecover`.

These are my thoughts on this, would love any suggestions.

